### PR TITLE
Add dedicated non-turbo jump button

### DIFF
--- a/source/Patches/VehicleController_Patch.cs
+++ b/source/Patches/VehicleController_Patch.cs
@@ -75,6 +75,7 @@ namespace BetterVehicleControls.Patches
             
             inputActionAsset.FindAction("Jump", false).performed -= __instance.DoTurboBoost;
             PluginLoader.VehicleControlsInstance.TurboKey.performed += __instance.DoTurboBoost;
+            PluginLoader.VehicleControlsInstance.JumpKey.performed += DoJump;
 
             PluginLoader.VehicleControlsInstance.GearShiftForwardKey.performed += ChangeGear_Forward;
             PluginLoader.VehicleControlsInstance.GearShiftBackwardKey.performed += ChangeGear_Backward;
@@ -263,6 +264,28 @@ namespace BetterVehicleControls.Patches
             {
                 vehicle.SetHonkingLocalClient(!vehicle.honkingHorn);
             }
+        }
+
+        public static void DoJump(InputAction.CallbackContext context)
+        {
+            if (!context.performed) return;
+
+            VehicleController vehicle = GetControlledVehicle();
+            if (vehicle == null) return;
+
+            if(vehicle.turboBoosts == 0)
+            {
+                vehicle.DoTurboBoost(context);
+                return;
+            }
+
+            if (vehicle.jumpingInCar || vehicle.keyIsInDriverHand) return;
+
+            int storedBoosts = vehicle.turboBoosts;
+            vehicle.turboBoosts = 0;
+            Vector2 sideBoostVector = IngamePlayerSettings.Instance.playerInput.actions.FindAction("Move", false).ReadValue<Vector2>();
+            vehicle.UseTurboBoostLocalClient(sideBoostVector);
+            vehicle.turboBoosts = storedBoosts;
         }
 
         [HarmonyPatch(typeof(VehicleController), "AddTurboBoost")]

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -88,6 +88,9 @@ namespace BetterVehicleControls
         [InputAction(KeyboardControl.B, Name = "Boost", GamepadControl = GamepadControl.ButtonNorth)]
         public InputAction TurboKey { get; set; }
 
+        [InputAction(KeyboardControl.C, Name = "Jump")]
+        public InputAction JumpKey { get; set; }
+
         [InputAction(KeyboardControl.W, Name = "Drive Forward", GamepadPath = "<Gamepad>/leftStick/up")]
         public InputAction MoveForwardsKey { get; set; }
 


### PR DESCRIPTION
This addition allows the player to do regular car jumping while having turbo boosts charged, default button C.

If boosts are charged, other players will not hear the car jump sound effect when jumping. This is the only effect of `VehicleController.UseTurboBoostServerRpc` when used on a non-turbo jump, and this addition will not call this method when turbos are charged. I could not find a solution to this problem but decided it was relatively minor.